### PR TITLE
Fix/text field icon

### DIFF
--- a/design_system/src/main/java/com/cairosquad/design_system/component/InputField.kt
+++ b/design_system/src/main/java/com/cairosquad/design_system/component/InputField.kt
@@ -10,7 +10,6 @@ import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.size
-import androidx.compose.foundation.shape.CircleShape
 import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.foundation.text.BasicText
 import androidx.compose.foundation.text.BasicTextField
@@ -179,7 +178,6 @@ private fun TextFieldIcon(
             contentDescription = null,
             tint = if (isFocused) Theme.color.surfaces.onSurface else Theme.color.surfaces.onSurfaceContainer,
             modifier = modifier
-                .clip(CircleShape)
                 .size(20.dp)
                 .then(
                     if (onClick != null) {

--- a/ui/src/main/java/com/cairosquad/ui/search/content/SearchContent.kt
+++ b/ui/src/main/java/com/cairosquad/ui/search/content/SearchContent.kt
@@ -27,7 +27,6 @@ import com.cairosquad.design_system.component.SectionHeader
 import com.cairosquad.design_system.theme.Theme
 import com.cairosquad.viewmodel.searchviewmodel.SearchInteractionListener
 import com.cairosquad.viewmodel.searchviewmodel.SearchUiState
-//import com.cairosquad.ui.R
 
 @Composable
 fun SearchContent(


### PR DESCRIPTION
This pull request includes changes to improve the design system and clean up unused imports in the codebase. The most important changes involve removing unnecessary shapes and imports to simplify the code and enhance maintainability.

### Design system improvements:

* [`design_system/src/main/java/com/cairosquad/design_system/component/InputField.kt`](diffhunk://#diff-0772261fe0e760ef28c996523df5b8176885bb60f6f269ec15709085106407f0L13): Removed `CircleShape` from the `TextFieldIcon` modifier to simplify the design and ensure consistency with other components. Also removed the `CircleShape` import as it is no longer used. [[1]](diffhunk://#diff-0772261fe0e760ef28c996523df5b8176885bb60f6f269ec15709085106407f0L13) [[2]](diffhunk://#diff-0772261fe0e760ef28c996523df5b8176885bb60f6f269ec15709085106407f0L182)

### Code cleanup:

* [`ui/src/main/java/com/cairosquad/ui/search/content/SearchContent.kt`](diffhunk://#diff-09b73183792b0f45f4348cd9463660bff49ffab6f5698c7e69ce7648e3f2f18aL30): Removed an unused import (`com.cairosquad.ui.R`) to clean up the codebase and improve readability.
<img width="316" height="133" alt="image" src="https://github.com/user-attachments/assets/244ac6f7-5162-456b-90e9-3115fed8567b" />
