### PR TITLE
fix : fix crashing of the image when app offline

### DIFF
--- a/safe_image_viewer/src/main/java/com/cairosquad/safe_image_viewer/loader/CoilImageLoader.kt
+++ b/safe_image_viewer/src/main/java/com/cairosquad/safe_image_viewer/loader/CoilImageLoader.kt
@@ -21,7 +21,7 @@ internal class CoilImageLoader(private val context: Context) {
             return (drawableResult as? BitmapDrawable)?.bitmap
         }
         catch(e:Exception){
-            TODO("handel exception here")
+          //  TODO("handel exception here")
             // i return null to use it at ui
             return null
 

--- a/safe_image_viewer/src/main/java/com/cairosquad/safe_image_viewer/loader/CoilImageLoader.kt
+++ b/safe_image_viewer/src/main/java/com/cairosquad/safe_image_viewer/loader/CoilImageLoader.kt
@@ -9,12 +9,23 @@ import coil.request.ImageRequest
 
 @Immutable
 internal class CoilImageLoader(private val context: Context) {
-    suspend fun loadBitmap(url: String): Bitmap {
-        val loader = ImageLoader(context)
-        val request = ImageRequest.Builder(context)
-            .data(url)
-            .allowHardware(false)
-            .build()
-        return (loader.execute(request).drawable as BitmapDrawable).bitmap
+    suspend fun loadBitmap(url: String): Bitmap?{
+        try {
+            val loader = ImageLoader(context)
+            val request = ImageRequest.Builder(context)
+                .data(url)
+                .allowHardware(false)
+                .build()
+            val drawableResult=loader.execute(request).drawable
+
+            return (drawableResult as? BitmapDrawable)?.bitmap
+        }
+        catch(e:Exception){
+            TODO("handel exception here")
+            // i return null to use it at ui
+            return null
+
+
+        }
     }
 }

--- a/safe_image_viewer/src/main/java/com/cairosquad/safe_image_viewer/loader/CoilImageLoader.kt
+++ b/safe_image_viewer/src/main/java/com/cairosquad/safe_image_viewer/loader/CoilImageLoader.kt
@@ -21,7 +21,7 @@ internal class CoilImageLoader(private val context: Context) {
             return (drawableResult as? BitmapDrawable)?.bitmap
         }
         catch(e:Exception){
-          //  TODO("handel exception here")
+            //handel exception here
             // i return null to use it at ui
             return null
 

--- a/safe_image_viewer/src/main/java/com/cairosquad/safe_image_viewer/loader/CoilImageLoader.kt
+++ b/safe_image_viewer/src/main/java/com/cairosquad/safe_image_viewer/loader/CoilImageLoader.kt
@@ -9,23 +9,19 @@ import coil.request.ImageRequest
 
 @Immutable
 internal class CoilImageLoader(private val context: Context) {
-    suspend fun loadBitmap(url: String): Bitmap?{
+    suspend fun loadBitmap(url: String): Bitmap? {
         try {
             val loader = ImageLoader(context)
             val request = ImageRequest.Builder(context)
                 .data(url)
                 .allowHardware(false)
                 .build()
-            val drawableResult=loader.execute(request).drawable
-
+            val drawableResult = loader.execute(request).drawable
             return (drawableResult as? BitmapDrawable)?.bitmap
-        }
-        catch(e:Exception){
+        } catch (e: Exception) {
             //handel exception here
             // i return null to use it at ui
             return null
-
-
         }
     }
 }

--- a/safe_image_viewer/src/main/java/com/cairosquad/safe_image_viewer/safe_image_viewer/SafeImageViewer.kt
+++ b/safe_image_viewer/src/main/java/com/cairosquad/safe_image_viewer/safe_image_viewer/SafeImageViewer.kt
@@ -120,13 +120,15 @@ fun SafeImageViewer(
             val classifier = SafeImageClassifier(context)
             bitmap = CoilImageLoader(context).loadBitmap(model)
 
-            withContext(Dispatchers.Unconfined) {
-                isImageSafe = classifier.isInappropriate(
-                    bitmap = bitmap!!,
-                    nsfwThreshold = nudeThreshold,
-                    sfwThreshold = nonNudeThreshold,
-                    isLogEnabled = enableLog
-                )
+            if (bitmap != null) {
+                withContext(Dispatchers.Unconfined) {
+                    isImageSafe = classifier.isInappropriate(
+                        bitmap = bitmap!!,
+                        nsfwThreshold = nudeThreshold,
+                        sfwThreshold = nonNudeThreshold,
+                        isLogEnabled = enableLog
+                    )
+                }
             }
         }
         hasClassificationCompleted = true
@@ -140,35 +142,37 @@ fun SafeImageViewer(
             contentAlignment = Alignment.Center
         ) {
             if (it) {
-                AsyncImage(
-                    modifier = Modifier
-                        .matchParentSize()
-                        .imageBlur(
-                            isBlurEnabled = isBlurEnabled,
-                            isImageSafe = isImageSafe,
-                            blur = blur.dp,
-                            bitmap = bitmap!!
-                        ),
-                    model = bitmap,
-                    contentDescription = contentDescription,
-                    contentScale = contentScale,
-                    filterQuality = filterQuality,
-                    alpha = alpha,
-                    alignment = alignment,
-                    colorFilter = colorFilter,
-                    placeholder = placeholder,
-                    error = error,
-                )
-                if (!isImageSafe && onToggleBlur != null) {
-                    Box(
+                if (bitmap != null) {
+                    AsyncImage(
                         modifier = Modifier
-                            .align(Alignment.Center)
-                            .clickable { isBlurEnabled = !isBlurEnabled }
-                    ) {
-                        onToggleBlur()
+                            .matchParentSize()
+                            .imageBlur(
+                                isBlurEnabled = isBlurEnabled,
+                                isImageSafe = isImageSafe,
+                                blur = blur.dp,
+                                bitmap = bitmap!!
+                            ),
+                        model = bitmap,
+                        contentDescription = contentDescription,
+                        contentScale = contentScale,
+                        filterQuality = filterQuality,
+                        alpha = alpha,
+                        alignment = alignment,
+                        colorFilter = colorFilter,
+                        placeholder = placeholder,
+                        error = error,
+                    )
+                    if (!isImageSafe && onToggleBlur != null) {
+                        Box(
+                            modifier = Modifier
+                                .align(Alignment.Center)
+                                .clickable { isBlurEnabled = !isBlurEnabled }
+                        ) {
+                            onToggleBlur()
+                        }
                     }
                 }
-            } else {
+            }else {
                 loadingPlaceholder()
             }
         }

--- a/safe_image_viewer/src/main/java/com/cairosquad/safe_image_viewer/safe_image_viewer/SafeImageViewer.kt
+++ b/safe_image_viewer/src/main/java/com/cairosquad/safe_image_viewer/safe_image_viewer/SafeImageViewer.kt
@@ -172,7 +172,7 @@ fun SafeImageViewer(
                         }
                     }
                 }
-            }else {
+            } else {
                 loadingPlaceholder()
             }
         }


### PR DESCRIPTION
why app crashes??
when you open the app and there is an internet then quickly turn off the internet 
the images is not cashed or partially stored so when you open again the app offline it crashes
i thought that this line "  return (loader.execute(request).drawable as BitmapDrawable).bitmap " is the reason of crash because we try to cast null image so i handled it in my pr , and i want to you to simulate this behaviour to ensure not crashing 