### PR TITLE
refactor: rename SearchUiState to SearchScreenState

### DIFF
--- a/ui/src/main/java/com/cairosquad/ui/search/content/ExploreScreenContent.kt
+++ b/ui/src/main/java/com/cairosquad/ui/search/content/ExploreScreenContent.kt
@@ -36,12 +36,12 @@ import com.cairosquad.design_system.component.SectionHeader
 import com.cairosquad.design_system.modifier.dropShadow
 import com.cairosquad.design_system.theme.Theme
 import com.cairosquad.viewmodel.searchviewmodel.SearchInteractionListener
-import com.cairosquad.viewmodel.searchviewmodel.SearchUiState
+import com.cairosquad.viewmodel.searchviewmodel.SearchScreenState
 
 @Composable
 fun ExploreScreenContent(
     modifier: Modifier = Modifier,
-    state: SearchUiState,
+    state: SearchScreenState,
     listener: SearchInteractionListener
 ) {
 

--- a/ui/src/main/java/com/cairosquad/ui/search/content/SearchContent.kt
+++ b/ui/src/main/java/com/cairosquad/ui/search/content/SearchContent.kt
@@ -29,11 +29,11 @@ import com.cairosquad.design_system.component.RecentSearchItem
 import com.cairosquad.design_system.component.SectionHeader
 import com.cairosquad.design_system.theme.Theme
 import com.cairosquad.viewmodel.searchviewmodel.SearchInteractionListener
-import com.cairosquad.viewmodel.searchviewmodel.SearchUiState
+import com.cairosquad.viewmodel.searchviewmodel.SearchScreenState
 
 @Composable
 fun SearchContent(
-    state: SearchUiState,
+    state: SearchScreenState,
     listener: SearchInteractionListener,
     modifier: Modifier = Modifier,
 ) {

--- a/ui/src/main/java/com/cairosquad/ui/search/content/SearchFailContent.kt
+++ b/ui/src/main/java/com/cairosquad/ui/search/content/SearchFailContent.kt
@@ -15,11 +15,11 @@ import com.cairosquad.design_system.component.InputField
 import com.cairosquad.design_system.component.StateMessage
 import com.cairosquad.design_system.theme.Theme
 import com.cairosquad.viewmodel.searchviewmodel.SearchInteractionListener
-import com.cairosquad.viewmodel.searchviewmodel.SearchUiState
+import com.cairosquad.viewmodel.searchviewmodel.SearchScreenState
 
 @Composable
 fun SearchFailContent(
-    state: SearchUiState,
+    state: SearchScreenState,
     listener: SearchInteractionListener,
     modifier: Modifier = Modifier,
 ) {

--- a/ui/src/main/java/com/cairosquad/ui/search/content/SearchLoadingContent.kt
+++ b/ui/src/main/java/com/cairosquad/ui/search/content/SearchLoadingContent.kt
@@ -14,11 +14,11 @@ import com.cairosquad.design_system.component.InputField
 import com.cairosquad.design_system.component.LoadingMovieCard
 import com.cairosquad.design_system.theme.Theme
 import com.cairosquad.viewmodel.searchviewmodel.SearchInteractionListener
-import com.cairosquad.viewmodel.searchviewmodel.SearchUiState
+import com.cairosquad.viewmodel.searchviewmodel.SearchScreenState
 
 @Composable
 fun SearchLoadingContent(
-    state: SearchUiState,
+    state: SearchScreenState,
     listener: SearchInteractionListener,
     modifier: Modifier = Modifier
 ) {

--- a/ui/src/main/java/com/cairosquad/ui/search/content/SearchResultContent.kt
+++ b/ui/src/main/java/com/cairosquad/ui/search/content/SearchResultContent.kt
@@ -35,11 +35,11 @@ import com.cairosquad.design_system.component.TopBar
 import com.cairosquad.design_system.text_style.defaultTextStyle
 import com.cairosquad.design_system.theme.Theme
 import com.cairosquad.viewmodel.searchviewmodel.SearchInteractionListener
-import com.cairosquad.viewmodel.searchviewmodel.SearchUiState
+import com.cairosquad.viewmodel.searchviewmodel.SearchScreenState
 
 @Composable
 fun SearchResultContent(
-    state: SearchUiState,
+    state: SearchScreenState,
     listener: SearchInteractionListener,
     modifier: Modifier = Modifier
 ) {
@@ -125,7 +125,7 @@ fun SearchResultContent(
 
 @Composable
 private fun AllResultsTabContent(
-    topResults: List<SearchUiState.MovieUiState>,
+    topResults: List<SearchScreenState.MovieScreenState>,
     modifier: Modifier = Modifier
 ) {
     if (topResults.isEmpty()) {
@@ -162,7 +162,7 @@ private fun AllResultsTabContent(
 
 @Composable
 private fun MoviesTabContent(
-    movies: List<SearchUiState.MovieUiState>,
+    movies: List<SearchScreenState.MovieScreenState>,
     modifier: Modifier = Modifier
 ) {
     if (movies.isEmpty()) {
@@ -194,7 +194,7 @@ private fun MoviesTabContent(
 
 @Composable
 private fun SeriesTabContent(
-    series: List<SearchUiState.SeriesUiState>,
+    series: List<SearchScreenState.SeriesScreenState>,
     modifier: Modifier = Modifier
 ) {
     if (series.isEmpty()) {
@@ -226,7 +226,7 @@ private fun SeriesTabContent(
 
 @Composable
 private fun ArtistsTabContent(
-    artists: List<SearchUiState.ArtistUiState>,
+    artists: List<SearchScreenState.ArtistScreenState>,
     modifier: Modifier = Modifier
 ) {
     if (artists.isEmpty()) {

--- a/ui/src/main/java/com/cairosquad/ui/search/content/SearchScreenContent.kt
+++ b/ui/src/main/java/com/cairosquad/ui/search/content/SearchScreenContent.kt
@@ -3,16 +3,16 @@ package com.cairosquad.ui.search.content
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Modifier
 import com.cairosquad.viewmodel.searchviewmodel.SearchInteractionListener
-import com.cairosquad.viewmodel.searchviewmodel.SearchUiState
+import com.cairosquad.viewmodel.searchviewmodel.SearchScreenState
 
 @Composable
 fun SearchScreenContent(
-    state: SearchUiState,
+    state: SearchScreenState,
     listener: SearchInteractionListener,
     modifier: Modifier = Modifier,
 ) {
     when (state.screenStatus) {
-        SearchUiState.ScreenStatus.EXPLORE -> {
+        SearchScreenState.ScreenStatus.EXPLORE -> {
             ExploreScreenContent(
                 modifier = modifier,
                 state = state,
@@ -20,7 +20,7 @@ fun SearchScreenContent(
             )
         }
 
-        SearchUiState.ScreenStatus.SEARCH -> {
+        SearchScreenState.ScreenStatus.SEARCH -> {
             SearchContent(
                 modifier = modifier,
                 state = state,
@@ -28,7 +28,7 @@ fun SearchScreenContent(
             )
         }
 
-        SearchUiState.ScreenStatus.RESULT -> {
+        SearchScreenState.ScreenStatus.RESULT -> {
             SearchResultContent(
                 modifier = modifier,
                 state = state,
@@ -36,7 +36,7 @@ fun SearchScreenContent(
             )
         }
 
-        SearchUiState.ScreenStatus.LOADING -> {
+        SearchScreenState.ScreenStatus.LOADING -> {
             SearchLoadingContent(
                 modifier = modifier,
                 state = state,
@@ -44,7 +44,7 @@ fun SearchScreenContent(
             )
         }
 
-        SearchUiState.ScreenStatus.FAILED -> {
+        SearchScreenState.ScreenStatus.FAILED -> {
             SearchFailContent(
                 modifier = modifier,
                 state = state,

--- a/viewmodel/src/main/java/com/cairosquad/viewmodel/searchviewmodel/SearchScreenState.kt
+++ b/viewmodel/src/main/java/com/cairosquad/viewmodel/searchviewmodel/SearchScreenState.kt
@@ -1,30 +1,30 @@
 package com.cairosquad.viewmodel.searchviewmodel
 
-data class SearchUiState(
+data class SearchScreenState(
     val query: String = "",
     val screenStatus: ScreenStatus = ScreenStatus.LOADING,
     val errorMessage: String? = null,
     val recentSearch: List<String> = emptyList(),
-    val forYou: List<MovieUiState> = emptyList(),
-    val exploreMore: List<MovieUiState> = emptyList(),
-    val movies: List<MovieUiState> = emptyList(),
-    val series: List<SeriesUiState> = emptyList(),
-    val artists: List<ArtistUiState> = emptyList(),
+    val forYou: List<MovieScreenState> = emptyList(),
+    val exploreMore: List<MovieScreenState> = emptyList(),
+    val movies: List<MovieScreenState> = emptyList(),
+    val series: List<SeriesScreenState> = emptyList(),
+    val artists: List<ArtistScreenState> = emptyList(),
 ) {
-    data class ArtistUiState(
+    data class ArtistScreenState(
         val id: Long,
         val name: String,
         val photoPath: String
     )
 
-    data class MovieUiState(
+    data class MovieScreenState(
         val id: Long,
         val title: String,
         val rating: Float,
         val posterPath: String,
     )
 
-    data class SeriesUiState(
+    data class SeriesScreenState(
         val id: Long,
         val title: String,
         val rating: Float,

--- a/viewmodel/src/main/java/com/cairosquad/viewmodel/searchviewmodel/SearchViewModel.kt
+++ b/viewmodel/src/main/java/com/cairosquad/viewmodel/searchviewmodel/SearchViewModel.kt
@@ -17,7 +17,7 @@ class SearchViewModel(
     private val clearRecentSearchUseCase: ClearRecentSearchUseCase,
     private val getExploreMoreUseCase: GetExploreMoreUseCase,
     private val getForYouUseCase: GetForYouUseCase,
-) : BaseViewModel<SearchUiState, SearchUiEvent>(initialState = SearchUiState()),
+) : BaseViewModel<SearchScreenState, SearchUiEvent>(initialState = SearchScreenState()),
     SearchInteractionListener {
 
     private var searchJob: Job? = null
@@ -35,7 +35,7 @@ class SearchViewModel(
         onSuccess = { (forYou, exploreMore) ->
             updateState {
                 it.copy(
-                    screenStatus = SearchUiState.ScreenStatus.EXPLORE,
+                    screenStatus = SearchScreenState.ScreenStatus.EXPLORE,
                     forYou = forYou,
                     exploreMore = exploreMore,
                     errorMessage = null
@@ -46,7 +46,7 @@ class SearchViewModel(
             val message = mapExceptionToMessage(e)
             updateState {
                 it.copy(
-                    screenStatus = SearchUiState.ScreenStatus.FAILED,
+                    screenStatus = SearchScreenState.ScreenStatus.FAILED,
                     errorMessage = message
                 )
             }
@@ -58,7 +58,7 @@ class SearchViewModel(
     override fun onQueryTextChanged(query: String) {
         updateState {
             it.copy(
-                screenStatus = SearchUiState.ScreenStatus.SEARCH,
+                screenStatus = SearchScreenState.ScreenStatus.SEARCH,
                 query = query
             )
         }
@@ -84,7 +84,7 @@ class SearchViewModel(
         searchJob?.cancel()
         updateState {
             it.copy(
-                screenStatus = SearchUiState.ScreenStatus.EXPLORE,
+                screenStatus = SearchScreenState.ScreenStatus.EXPLORE,
                 query = "",
                 recentSearch = emptyList(),
                 errorMessage = null
@@ -96,7 +96,7 @@ class SearchViewModel(
         searchJob?.cancel()
         updateState {
             it.copy(
-                screenStatus = SearchUiState.ScreenStatus.LOADING,
+                screenStatus = SearchScreenState.ScreenStatus.LOADING,
                 query = query,
                 errorMessage = null
             )
@@ -105,7 +105,7 @@ class SearchViewModel(
         if (query.isBlank()) {
             updateState {
                 it.copy(
-                    screenStatus = SearchUiState.ScreenStatus.SEARCH,
+                    screenStatus = SearchScreenState.ScreenStatus.SEARCH,
                 )
             }
         } else {
@@ -119,7 +119,7 @@ class SearchViewModel(
                 onSuccess = { (movies, series, artists) ->
                     updateState {
                         it.copy(
-                            screenStatus = SearchUiState.ScreenStatus.RESULT,
+                            screenStatus = SearchScreenState.ScreenStatus.RESULT,
                             movies = movies,
                             series = series,
                             artists = artists,
@@ -131,7 +131,7 @@ class SearchViewModel(
                     val message = mapExceptionToMessage(e)
                     updateState {
                         it.copy(
-                            screenStatus = SearchUiState.ScreenStatus.FAILED,
+                            screenStatus = SearchScreenState.ScreenStatus.FAILED,
                             errorMessage = message
                         )
                     }
@@ -184,14 +184,14 @@ class SearchViewModel(
     override fun onBackClicked() {
         updateState {
             when (it.screenStatus) {
-                SearchUiState.ScreenStatus.SEARCH -> it.copy(
-                    screenStatus = SearchUiState.ScreenStatus.EXPLORE,
+                SearchScreenState.ScreenStatus.SEARCH -> it.copy(
+                    screenStatus = SearchScreenState.ScreenStatus.EXPLORE,
                     query = "",
                     recentSearch = emptyList(),
                 )
 
-                SearchUiState.ScreenStatus.RESULT -> it.copy(
-                    screenStatus = SearchUiState.ScreenStatus.SEARCH,
+                SearchScreenState.ScreenStatus.RESULT -> it.copy(
+                    screenStatus = SearchScreenState.ScreenStatus.SEARCH,
                 )
 
                 else -> it
@@ -213,7 +213,7 @@ class SearchViewModel(
         searchJob?.cancel()
         updateState {
             it.copy(
-                screenStatus = SearchUiState.ScreenStatus.SEARCH,
+                screenStatus = SearchScreenState.ScreenStatus.SEARCH,
             )
         }
     }

--- a/viewmodel/src/main/java/com/cairosquad/viewmodel/searchviewmodel/mapper.kt
+++ b/viewmodel/src/main/java/com/cairosquad/viewmodel/searchviewmodel/mapper.kt
@@ -4,20 +4,20 @@ import com.cairosquad.entity.Artist
 import com.cairosquad.entity.Movie
 import com.cairosquad.entity.Series
 
-fun Movie.toUiState() = SearchUiState.MovieUiState(
+fun Movie.toUiState() = SearchScreenState.MovieScreenState(
     id = id,
     title = title,
     rating = rating / 2,
     posterPath = posterPath
 )
 
-fun Artist.toUiState() = SearchUiState.ArtistUiState(
+fun Artist.toUiState() = SearchScreenState.ArtistScreenState(
     id = id,
     name = name,
     photoPath = photoPath
 )
 
-fun Series.toUiState() = SearchUiState.SeriesUiState(
+fun Series.toUiState() = SearchScreenState.SeriesScreenState(
     id = id,
     title = title,
     rating = rating / 2,

--- a/viewmodel/src/test/java/com/cairosquad/viewmodel/searchviewmodel/SearchViewModelTest.kt
+++ b/viewmodel/src/test/java/com/cairosquad/viewmodel/searchviewmodel/SearchViewModelTest.kt
@@ -92,7 +92,7 @@ class SearchViewModelTest {
 
         delay(400)
 
-        assertThat(viewModel.uiState.value.screenStatus).isEqualTo(SearchUiState.ScreenStatus.EXPLORE)
+        assertThat(viewModel.uiState.value.screenStatus).isEqualTo(SearchScreenState.ScreenStatus.EXPLORE)
         assertThat(viewModel.uiState.value.forYou).isEqualTo(forYouList.map { it.toUiState() })
         assertThat(viewModel.uiState.value.exploreMore).isEqualTo(exploreMoreList.map { it.toUiState() })
     }
@@ -106,7 +106,7 @@ class SearchViewModelTest {
 
         delay(400)
 
-        assertThat(viewModel.uiState.value.screenStatus).isEqualTo(SearchUiState.ScreenStatus.FAILED)
+        assertThat(viewModel.uiState.value.screenStatus).isEqualTo(SearchScreenState.ScreenStatus.FAILED)
         assertThat(viewModel.uiState.value.errorMessage).contains("Network error. Please check your connection")
     }
 
@@ -126,7 +126,7 @@ class SearchViewModelTest {
     @Test
     fun `onCancelSearch clears query and sets to EXPLORE`() = runBlocking {
         viewModel.onCancelSearch()
-        assertThat(viewModel.uiState.value.screenStatus).isEqualTo(SearchUiState.ScreenStatus.EXPLORE)
+        assertThat(viewModel.uiState.value.screenStatus).isEqualTo(SearchScreenState.ScreenStatus.EXPLORE)
         assertThat(viewModel.uiState.value.query).isEmpty()
     }
 
@@ -139,7 +139,7 @@ class SearchViewModelTest {
 
         viewModel.onSearch(query)
         delay(400)
-        assertThat(viewModel.uiState.value.screenStatus).isEqualTo(SearchUiState.ScreenStatus.RESULT)
+        assertThat(viewModel.uiState.value.screenStatus).isEqualTo(SearchScreenState.ScreenStatus.RESULT)
         assertThat(viewModel.uiState.value.movies).hasSize(1)
         assertThat(viewModel.uiState.value.series).hasSize(1)
         assertThat(viewModel.uiState.value.artists).hasSize(1)
@@ -153,7 +153,7 @@ class SearchViewModelTest {
 
         viewModel.onSearch("fail")
         delay(400)
-        assertThat(viewModel.uiState.value.screenStatus).isEqualTo(SearchUiState.ScreenStatus.FAILED)
+        assertThat(viewModel.uiState.value.screenStatus).isEqualTo(SearchScreenState.ScreenStatus.FAILED)
         assertThat(viewModel.uiState.value.errorMessage).contains("Network")
     }
 
@@ -161,7 +161,7 @@ class SearchViewModelTest {
     fun `onSearch does not go to result screen when query is blank`() = runBlocking {
         viewModel.onSearch("    ")
         delay(400)
-        assertThat(viewModel.uiState.value.screenStatus).isNotEqualTo(SearchUiState.ScreenStatus.RESULT)
+        assertThat(viewModel.uiState.value.screenStatus).isNotEqualTo(SearchScreenState.ScreenStatus.RESULT)
     }
 
     @Test
@@ -173,7 +173,7 @@ class SearchViewModelTest {
 
         viewModel.onRecentSearchItemClicked(query)
         delay(400)
-        assertThat(viewModel.uiState.value.screenStatus).isEqualTo(SearchUiState.ScreenStatus.RESULT)
+        assertThat(viewModel.uiState.value.screenStatus).isEqualTo(SearchScreenState.ScreenStatus.RESULT)
     }
 
     @Test
@@ -211,7 +211,7 @@ class SearchViewModelTest {
         delay(300)
         viewModel.onBackClicked()
         delay(300)
-        assertThat(viewModel.uiState.value.screenStatus).isEqualTo(SearchUiState.ScreenStatus.EXPLORE)
+        assertThat(viewModel.uiState.value.screenStatus).isEqualTo(SearchScreenState.ScreenStatus.EXPLORE)
     }
 
     @Test
@@ -223,7 +223,7 @@ class SearchViewModelTest {
 
         delay(400)
 
-        assertThat(viewModel.uiState.value.screenStatus).isEqualTo(SearchUiState.ScreenStatus.SEARCH)
+        assertThat(viewModel.uiState.value.screenStatus).isEqualTo(SearchScreenState.ScreenStatus.SEARCH)
         assertThat(viewModel.uiState.value.recentSearch).isEqualTo(recent)
     }
 }


### PR DESCRIPTION
This pull request refactors the `SearchUiState` to `SearchScreenState` across the codebase to better align with the application's naming conventions and improve clarity in representing screen-specific states. The changes include updates to the state model, view model, composable functions, and associated tests.

### State Model Refactoring:
* Renamed `SearchUiState` to `SearchScreenState` and updated its properties to use corresponding `ScreenState` types for movies, series, and artists. (`viewmodel/src/main/java/com/cairosquad/viewmodel/searchviewmodel/SearchScreenState.kt`)

### View Model Updates:
* Updated `SearchViewModel` to use `SearchScreenState` instead of `SearchUiState` for initial state and screen status handling. (`viewmodel/src/main/java/com/cairosquad/viewmodel/searchviewmodel/SearchViewModel.kt`) [[1]](diffhunk://#diff-2fa637d7f4e20ddf9b74df5359584779f389425164b85aa7894d322c6648938dL20-R20) [[2]](diffhunk://#diff-2fa637d7f4e20ddf9b74df5359584779f389425164b85aa7894d322c6648938dL38-R38) [[3]](diffhunk://#diff-2fa637d7f4e20ddf9b74df5359584779f389425164b85aa7894d322c6648938dL49-R49) [[4]](diffhunk://#diff-2fa637d7f4e20ddf9b74df5359584779f389425164b85aa7894d322c6648938dL61-R61) [[5]](diffhunk://#diff-2fa637d7f4e20ddf9b74df5359584779f389425164b85aa7894d322c6648938dL87-R87) [[6]](diffhunk://#diff-2fa637d7f4e20ddf9b74df5359584779f389425164b85aa7894d322c6648938dL99-R99) [[7]](diffhunk://#diff-2fa637d7f4e20ddf9b74df5359584779f389425164b85aa7894d322c6648938dL108-R108) [[8]](diffhunk://#diff-2fa637d7f4e20ddf9b74df5359584779f389425164b85aa7894d322c6648938dL122-R122) [[9]](diffhunk://#diff-2fa637d7f4e20ddf9b74df5359584779f389425164b85aa7894d322c6648938dL134-R134) [[10]](diffhunk://#diff-2fa637d7f4e20ddf9b74df5359584779f389425164b85aa7894d322c6648938dL187-R194) [[11]](diffhunk://#diff-2fa637d7f4e20ddf9b74df5359584779f389425164b85aa7894d322c6648938dL216-R216)

### Composable Function Adjustments:
* Replaced `SearchUiState` with `SearchScreenState` in all composable functions, including `SearchScreenContent`, `ExploreScreenContent`, `SearchContent`, `SearchFailContent`, `SearchLoadingContent`, and `SearchResultContent`. (`ui/src/main/java/com/cairosquad/ui/search/content`) [[1]](diffhunk://#diff-1b73bfdae79284b2734ad20f3cd8f7d1699774ec8ec5d59f2c36f26ff7595574L39-R44) [[2]](diffhunk://#diff-09b73183792b0f45f4348cd9463660bff49ffab6f5698c7e69ce7648e3f2f18aL32-R36) [[3]](diffhunk://#diff-fc7b67b303ac386cbe1788cd501ed27ddf5316f565c3b787e68934570412afb1L18-R22) [[4]](diffhunk://#diff-fd11dbf37defc46481182d87588f6199b81689a217f816904db21e9699db880dL17-R21) [[5]](diffhunk://#diff-cbeebff283c1c13aedfd35a07bb0a8e64b2001fd2102aaebc631e1e4f3c4683bL38-R42) [[6]](diffhunk://#diff-460ac1fd4983893271e77b7f6a3ddf33ffcd3e57f3b7785817f2287435d9801eL6-R47)

### Mapper Updates:
* Updated the mapping functions to convert entities to `SearchScreenState` types instead of `SearchUiState`. (`viewmodel/src/main/java/com/cairosquad/viewmodel/searchviewmodel/mapper.kt`)

### Test Case Modifications:
* Refactored test cases to validate the behavior of `SearchViewModel` with `SearchScreenState`. (`viewmodel/src/test/java/com/cairosquad/viewmodel/searchviewmodel/SearchViewModelTest.kt`) [[1]](diffhunk://#diff-511fd817a58727af0bf1a7ad9dad2bbc19514bbf2b679b6673058758cd508441L95-R95) [[2]](diffhunk://#diff-511fd817a58727af0bf1a7ad9dad2bbc19514bbf2b679b6673058758cd508441L109-R109) [[3]](diffhunk://#diff-511fd817a58727af0bf1a7ad9dad2bbc19514bbf2b679b6673058758cd508441L129-R129) [[4]](diffhunk://#diff-511fd817a58727af0bf1a7ad9dad2bbc19514bbf2b679b6673058758cd508441L142-R142)…nces