### PR TITLE
refactor: rename SearchUiEvent to SearchEffect

### DIFF
--- a/ui/src/main/java/com/cairosquad/ui/search/SearchScreen.kt
+++ b/ui/src/main/java/com/cairosquad/ui/search/SearchScreen.kt
@@ -14,7 +14,7 @@ fun SearchScreen(
     viewModel: SearchViewModel = koinViewModel(),
 ) {
 
-    val state by viewModel.uiState.collectAsState()
+    val state by viewModel.screenState.collectAsState()
 
     SearchScreenContent(
         state = state,

--- a/ui/src/main/java/com/cairosquad/ui/search/content/SearchResultContent.kt
+++ b/ui/src/main/java/com/cairosquad/ui/search/content/SearchResultContent.kt
@@ -128,7 +128,7 @@ fun SearchResultContent(
 
 @Composable
 private fun AllResultsTabContent(
-    topResults: List<SearchScreenState.MovieScreenState>,
+    topResults: List<SearchScreenState.MovieUiState>,
     modifier: Modifier = Modifier
 ) {
     AnimatedVisibility(
@@ -175,7 +175,7 @@ private fun AllResultsTabContent(
 
 @Composable
 private fun MoviesTabContent(
-    movies: List<SearchScreenState.MovieScreenState>,
+    movies: List<SearchScreenState.MovieUiState>,
     modifier: Modifier = Modifier
 ) {
     AnimatedVisibility(
@@ -221,7 +221,7 @@ private fun MoviesTabContent(
 
 @Composable
 private fun SeriesTabContent(
-    series: List<SearchScreenState.SeriesScreenState>,
+    series: List<SearchScreenState.SeriesUiState>,
     modifier: Modifier = Modifier
 ) {
     AnimatedVisibility(
@@ -267,7 +267,7 @@ private fun SeriesTabContent(
 
 @Composable
 private fun ArtistsTabContent(
-    artists: List<SearchScreenState.ArtistScreenState>,
+    artists: List<SearchScreenState.ArtistUiState>,
     modifier: Modifier = Modifier
 ) {
     AnimatedVisibility(

--- a/viewmodel/src/main/java/com/cairosquad/viewmodel/base/BaseViewModel.kt
+++ b/viewmodel/src/main/java/com/cairosquad/viewmodel/base/BaseViewModel.kt
@@ -20,14 +20,14 @@ abstract class BaseViewModel<T, E>(
     private val _uiState = MutableStateFlow(initialState)
     val uiState: StateFlow<T> = _uiState.asStateFlow()
 
-    private val _uiEvent = MutableSharedFlow<E>()
-    val uiEvent = _uiEvent.asSharedFlow()
+    private val _effect = MutableSharedFlow<E>()
+    val effect = _effect.asSharedFlow()
 
     protected fun updateState(transform: (T) -> T) {
         _uiState.update { transform(it) }
     }
 
-    protected fun sendEvent(
+    protected fun sendEffect(
         event: E,
         onStart: suspend () -> Unit = {},
         onEnd: suspend () -> Unit = {},
@@ -35,7 +35,7 @@ abstract class BaseViewModel<T, E>(
     ) {
         viewModelScope.launch(dispatcher) {
             onStart()
-            _uiEvent.emit(event)
+            _effect.emit(event)
             onEnd()
         }
     }

--- a/viewmodel/src/main/java/com/cairosquad/viewmodel/base/BaseViewModel.kt
+++ b/viewmodel/src/main/java/com/cairosquad/viewmodel/base/BaseViewModel.kt
@@ -17,14 +17,14 @@ abstract class BaseViewModel<T, E>(
     initialState: T
 ) : ViewModel() {
 
-    private val _uiState = MutableStateFlow(initialState)
-    val uiState: StateFlow<T> = _uiState.asStateFlow()
+    private val _screenState = MutableStateFlow(initialState)
+    val screenState: StateFlow<T> = _screenState.asStateFlow()
 
     private val _effect = MutableSharedFlow<E>()
     val effect = _effect.asSharedFlow()
 
     protected fun updateState(transform: (T) -> T) {
-        _uiState.update { transform(it) }
+        _screenState.update { transform(it) }
     }
 
     protected fun sendEffect(

--- a/viewmodel/src/main/java/com/cairosquad/viewmodel/searchviewmodel/SearchEffect.kt
+++ b/viewmodel/src/main/java/com/cairosquad/viewmodel/searchviewmodel/SearchEffect.kt
@@ -1,0 +1,5 @@
+package com.cairosquad.viewmodel.searchviewmodel
+
+sealed class SearchEffect {
+    data class ShowToast(val message: String) : SearchEffect()
+}

--- a/viewmodel/src/main/java/com/cairosquad/viewmodel/searchviewmodel/SearchScreenState.kt
+++ b/viewmodel/src/main/java/com/cairosquad/viewmodel/searchviewmodel/SearchScreenState.kt
@@ -5,26 +5,26 @@ data class SearchScreenState(
     val screenStatus: ScreenStatus = ScreenStatus.LOADING,
     val errorMessage: String? = null,
     val recentSearch: List<String> = emptyList(),
-    val forYou: List<MovieScreenState> = emptyList(),
-    val exploreMore: List<MovieScreenState> = emptyList(),
-    val movies: List<MovieScreenState> = emptyList(),
-    val series: List<SeriesScreenState> = emptyList(),
-    val artists: List<ArtistScreenState> = emptyList(),
+    val forYou: List<MovieUiState> = emptyList(),
+    val exploreMore: List<MovieUiState> = emptyList(),
+    val movies: List<MovieUiState> = emptyList(),
+    val series: List<SeriesUiState> = emptyList(),
+    val artists: List<ArtistUiState> = emptyList(),
 ) {
-    data class ArtistScreenState(
+    data class ArtistUiState(
         val id: Long,
         val name: String,
         val photoPath: String
     )
 
-    data class MovieScreenState(
+    data class MovieUiState(
         val id: Long,
         val title: String,
         val rating: Float,
         val posterPath: String,
     )
 
-    data class SeriesScreenState(
+    data class SeriesUiState(
         val id: Long,
         val title: String,
         val rating: Float,

--- a/viewmodel/src/main/java/com/cairosquad/viewmodel/searchviewmodel/SearchUiEvent.kt
+++ b/viewmodel/src/main/java/com/cairosquad/viewmodel/searchviewmodel/SearchUiEvent.kt
@@ -1,5 +1,0 @@
-package com.cairosquad.viewmodel.searchviewmodel
-
-sealed class SearchUiEvent {
-    data class ShowToast(val message: String) : SearchUiEvent()
-}

--- a/viewmodel/src/main/java/com/cairosquad/viewmodel/searchviewmodel/SearchViewModel.kt
+++ b/viewmodel/src/main/java/com/cairosquad/viewmodel/searchviewmodel/SearchViewModel.kt
@@ -17,7 +17,7 @@ class SearchViewModel(
     private val clearRecentSearchUseCase: ClearRecentSearchUseCase,
     private val getExploreMoreUseCase: GetExploreMoreUseCase,
     private val getForYouUseCase: GetForYouUseCase,
-) : BaseViewModel<SearchScreenState, SearchUiEvent>(initialState = SearchScreenState()),
+) : BaseViewModel<SearchScreenState, SearchEffect>(initialState = SearchScreenState()),
     SearchInteractionListener {
 
     private var searchJob: Job? = null
@@ -50,7 +50,7 @@ class SearchViewModel(
                     errorMessage = message
                 )
             }
-            sendEvent(SearchUiEvent.ShowToast(message))
+            sendEffect(SearchEffect.ShowToast(message))
         },
         dispatcher = Dispatchers.IO
     )
@@ -135,7 +135,7 @@ class SearchViewModel(
                             errorMessage = message
                         )
                     }
-                    sendEvent(SearchUiEvent.ShowToast(message))
+                    sendEffect(SearchEffect.ShowToast(message))
                 },
                 dispatcher = Dispatchers.IO
             )
@@ -156,7 +156,7 @@ class SearchViewModel(
             onError = { e ->
                 val message = mapExceptionToMessage(e)
                 updateState { it.copy(errorMessage = message) }
-                sendEvent(SearchUiEvent.ShowToast(message))
+                sendEffect(SearchEffect.ShowToast(message))
             },
             dispatcher = Dispatchers.IO
         )
@@ -174,7 +174,7 @@ class SearchViewModel(
             onError = { e ->
                 val message = mapExceptionToMessage(e)
                 updateState { it.copy(errorMessage = mapExceptionToMessage(e)) }
-                sendEvent(SearchUiEvent.ShowToast(message))
+                sendEffect(SearchEffect.ShowToast(message))
             },
             dispatcher = Dispatchers.IO
         )

--- a/viewmodel/src/main/java/com/cairosquad/viewmodel/searchviewmodel/mapper.kt
+++ b/viewmodel/src/main/java/com/cairosquad/viewmodel/searchviewmodel/mapper.kt
@@ -4,20 +4,20 @@ import com.cairosquad.entity.Artist
 import com.cairosquad.entity.Movie
 import com.cairosquad.entity.Series
 
-fun Movie.toUiState() = SearchScreenState.MovieScreenState(
+fun Movie.toUiState() = SearchScreenState.MovieUiState(
     id = id,
     title = title,
     rating = rating / 2,
     posterPath = posterPath
 )
 
-fun Artist.toUiState() = SearchScreenState.ArtistScreenState(
+fun Artist.toUiState() = SearchScreenState.ArtistUiState(
     id = id,
     name = name,
     photoPath = photoPath
 )
 
-fun Series.toUiState() = SearchScreenState.SeriesScreenState(
+fun Series.toUiState() = SearchScreenState.SeriesUiState(
     id = id,
     title = title,
     rating = rating / 2,

--- a/viewmodel/src/test/java/com/cairosquad/viewmodel/base/BaseViewModelTest.kt
+++ b/viewmodel/src/test/java/com/cairosquad/viewmodel/base/BaseViewModelTest.kt
@@ -40,7 +40,7 @@ class BaseViewModelTest {
             onEnd: suspend () -> Unit = {},
             dispatcher: CoroutineDispatcher = Dispatchers.Main
         ) {
-            sendEvent(
+            sendEffect(
                 event,
                 onStart,
                 onEnd,
@@ -92,10 +92,10 @@ class BaseViewModelTest {
     }
 
     @Test
-    fun sendEventShouldEmitEventCorrectly() = testScope.runTest {
+    fun sendEventShouldEmitEffectCorrectly() = testScope.runTest {
         val expectedEvent = TestEvent.TestEvent1
         var receivedEvent: TestEvent? = null
-        val job = launch { viewModel.uiEvent.collect { receivedEvent = it } }
+        val job = launch { viewModel.effect.collect { receivedEvent = it } }
 
         viewModel.sendTestEvent(expectedEvent)
 
@@ -136,7 +136,7 @@ class BaseViewModelTest {
     }
 
     @Test
-    fun sendEventShouldCallOnStartAndOnEndCallbacks() = testScope.runTest {
+    fun sendEffectShouldCallOnStartAndOnEndCallbacks() = testScope.runTest {
         var onStartCalled = false
         var onEndCalled = false
         val event = TestEvent.TestEvent2

--- a/viewmodel/src/test/java/com/cairosquad/viewmodel/base/BaseViewModelTest.kt
+++ b/viewmodel/src/test/java/com/cairosquad/viewmodel/base/BaseViewModelTest.kt
@@ -86,13 +86,13 @@ class BaseViewModelTest {
 
         viewModel.updateStateValue({ it.copy(value = newStateValue) })
 
-        val state = viewModel.uiState.first()
+        val state = viewModel.screenState.first()
         assertEquals(newStateValue, state.value)
         assertEquals(0, state.error)
     }
 
     @Test
-    fun sendEventShouldEmitEffectCorrectly() = testScope.runTest {
+    fun sendEffectShouldEmitEffectCorrectly() = testScope.runTest {
         val expectedEvent = TestEvent.TestEvent1
         var receivedEvent: TestEvent? = null
         val job = launch { viewModel.effect.collect { receivedEvent = it } }
@@ -114,7 +114,7 @@ class BaseViewModelTest {
             dispatcher = testDispatcher
         )
 
-        val state = viewModel.uiState.first()
+        val state = viewModel.screenState.first()
         assertEquals(newStateValue, state.value)
         assertEquals(0, state.error)
     }
@@ -130,7 +130,7 @@ class BaseViewModelTest {
             dispatcher = testDispatcher
         )
 
-        val state = viewModel.uiState.first()
+        val state = viewModel.screenState.first()
         assertEquals(0, state.value)
         assertEquals(newStateValue, state.error)
     }

--- a/viewmodel/src/test/java/com/cairosquad/viewmodel/searchviewmodel/SearchViewModelTest.kt
+++ b/viewmodel/src/test/java/com/cairosquad/viewmodel/searchviewmodel/SearchViewModelTest.kt
@@ -92,9 +92,9 @@ class SearchViewModelTest {
 
         delay(400)
 
-        assertThat(viewModel.uiState.value.screenStatus).isEqualTo(SearchScreenState.ScreenStatus.EXPLORE)
-        assertThat(viewModel.uiState.value.forYou).isEqualTo(forYouList.map { it.toUiState() })
-        assertThat(viewModel.uiState.value.exploreMore).isEqualTo(exploreMoreList.map { it.toUiState() })
+        assertThat(viewModel.screenState.value.screenStatus).isEqualTo(SearchScreenState.ScreenStatus.EXPLORE)
+        assertThat(viewModel.screenState.value.forYou).isEqualTo(forYouList.map { it.toUiState() })
+        assertThat(viewModel.screenState.value.exploreMore).isEqualTo(exploreMoreList.map { it.toUiState() })
     }
 
     @Test
@@ -106,8 +106,8 @@ class SearchViewModelTest {
 
         delay(400)
 
-        assertThat(viewModel.uiState.value.screenStatus).isEqualTo(SearchScreenState.ScreenStatus.FAILED)
-        assertThat(viewModel.uiState.value.errorMessage).contains("Network error. Please check your connection")
+        assertThat(viewModel.screenState.value.screenStatus).isEqualTo(SearchScreenState.ScreenStatus.FAILED)
+        assertThat(viewModel.screenState.value.errorMessage).contains("Network error. Please check your connection")
     }
 
     @Test
@@ -119,15 +119,15 @@ class SearchViewModelTest {
         viewModel.onQueryTextChanged(query)
 
         delay(400)
-        assertThat(viewModel.uiState.value.query).isEqualTo(query)
-        assertThat(viewModel.uiState.value.recentSearch).isEqualTo(recent)
+        assertThat(viewModel.screenState.value.query).isEqualTo(query)
+        assertThat(viewModel.screenState.value.recentSearch).isEqualTo(recent)
     }
 
     @Test
     fun `onCancelSearch clears query and sets to EXPLORE`() = runBlocking {
         viewModel.onCancelSearch()
-        assertThat(viewModel.uiState.value.screenStatus).isEqualTo(SearchScreenState.ScreenStatus.EXPLORE)
-        assertThat(viewModel.uiState.value.query).isEmpty()
+        assertThat(viewModel.screenState.value.screenStatus).isEqualTo(SearchScreenState.ScreenStatus.EXPLORE)
+        assertThat(viewModel.screenState.value.query).isEmpty()
     }
 
     @Test
@@ -139,10 +139,10 @@ class SearchViewModelTest {
 
         viewModel.onSearch(query)
         delay(400)
-        assertThat(viewModel.uiState.value.screenStatus).isEqualTo(SearchScreenState.ScreenStatus.RESULT)
-        assertThat(viewModel.uiState.value.movies).hasSize(1)
-        assertThat(viewModel.uiState.value.series).hasSize(1)
-        assertThat(viewModel.uiState.value.artists).hasSize(1)
+        assertThat(viewModel.screenState.value.screenStatus).isEqualTo(SearchScreenState.ScreenStatus.RESULT)
+        assertThat(viewModel.screenState.value.movies).hasSize(1)
+        assertThat(viewModel.screenState.value.series).hasSize(1)
+        assertThat(viewModel.screenState.value.artists).hasSize(1)
     }
 
     @Test
@@ -153,15 +153,15 @@ class SearchViewModelTest {
 
         viewModel.onSearch("fail")
         delay(400)
-        assertThat(viewModel.uiState.value.screenStatus).isEqualTo(SearchScreenState.ScreenStatus.FAILED)
-        assertThat(viewModel.uiState.value.errorMessage).contains("Network")
+        assertThat(viewModel.screenState.value.screenStatus).isEqualTo(SearchScreenState.ScreenStatus.FAILED)
+        assertThat(viewModel.screenState.value.errorMessage).contains("Network")
     }
 
     @Test
     fun `onSearch does not go to result screen when query is blank`() = runBlocking {
         viewModel.onSearch("    ")
         delay(400)
-        assertThat(viewModel.uiState.value.screenStatus).isNotEqualTo(SearchScreenState.ScreenStatus.RESULT)
+        assertThat(viewModel.screenState.value.screenStatus).isNotEqualTo(SearchScreenState.ScreenStatus.RESULT)
     }
 
     @Test
@@ -173,7 +173,7 @@ class SearchViewModelTest {
 
         viewModel.onRecentSearchItemClicked(query)
         delay(400)
-        assertThat(viewModel.uiState.value.screenStatus).isEqualTo(SearchScreenState.ScreenStatus.RESULT)
+        assertThat(viewModel.screenState.value.screenStatus).isEqualTo(SearchScreenState.ScreenStatus.RESULT)
     }
 
     @Test
@@ -184,7 +184,7 @@ class SearchViewModelTest {
 
         delay(400)
 
-        assertThat(viewModel.uiState.value.recentSearch).isEmpty()
+        assertThat(viewModel.screenState.value.recentSearch).isEmpty()
     }
 
     @Test
@@ -197,7 +197,7 @@ class SearchViewModelTest {
 
         delay(400)
 
-        assertThat(viewModel.uiState.value.recentSearch).isEqualTo(newList)
+        assertThat(viewModel.screenState.value.recentSearch).isEqualTo(newList)
     }
 
     @Test
@@ -211,7 +211,7 @@ class SearchViewModelTest {
         delay(300)
         viewModel.onBackClicked()
         delay(300)
-        assertThat(viewModel.uiState.value.screenStatus).isEqualTo(SearchScreenState.ScreenStatus.EXPLORE)
+        assertThat(viewModel.screenState.value.screenStatus).isEqualTo(SearchScreenState.ScreenStatus.EXPLORE)
     }
 
     @Test
@@ -223,7 +223,7 @@ class SearchViewModelTest {
 
         delay(400)
 
-        assertThat(viewModel.uiState.value.screenStatus).isEqualTo(SearchScreenState.ScreenStatus.SEARCH)
-        assertThat(viewModel.uiState.value.recentSearch).isEqualTo(recent)
+        assertThat(viewModel.screenState.value.screenStatus).isEqualTo(SearchScreenState.ScreenStatus.SEARCH)
+        assertThat(viewModel.screenState.value.recentSearch).isEqualTo(recent)
     }
 }


### PR DESCRIPTION
This pull request introduces several changes to improve the consistency and clarity of the `SearchScreenState` and `BaseViewModel` implementations, as well as their associated tests and mappers. The most significant updates include renaming state and event classes for better semantic alignment, refactoring the `BaseViewModel` to use "effects" instead of "events," and updating related tests and mappers accordingly.

### State and Event Renaming:
* [`viewmodel/src/main/java/com/cairosquad/viewmodel/searchviewmodel/SearchScreenState.kt`](diffhunk://#diff-ca18a216cd49ff1d86a5b454a1482789c5ee49c53816b7eefd1b6025f08729d1L8-R27): Renamed `MovieScreenState`, `SeriesScreenState`, and `ArtistScreenState` to `MovieUiState`, `SeriesUiState`, and `ArtistUiState` for improved semantic clarity.
* [`viewmodel/src/main/java/com/cairosquad/viewmodel/searchviewmodel/SearchUiEvent.kt`](diffhunk://#diff-56d008404c26cdc2d0a25576771cd7fbda5ca8cdc362f9936d76585e3745ccdcL1-L5): Removed `SearchUiEvent` and replaced it with `SearchEffect`. [[1]](diffhunk://#diff-56d008404c26cdc2d0a25576771cd7fbda5ca8cdc362f9936d76585e3745ccdcL1-L5) [[2]](diffhunk://#diff-bf3ad9cabe5734ca805aa446dd17a2dd0dcae815b5ec98e75db528cf4b77b590R1-R5)

### ViewModel Refactoring:
* [`viewmodel/src/main/java/com/cairosquad/viewmodel/base/BaseViewModel.kt`](diffhunk://#diff-63a36acf1040095d522da7d68dfc5156abf44b95600461e002f5d5d935058fe5L23-R38): Refactored `BaseViewModel` to use "effects" (`_effect`) instead of "events" (`_uiEvent`) and updated method names accordingly (e.g., `sendEvent` → `sendEffect`).
* [`viewmodel/src/main/java/com/cairosquad/viewmodel/searchviewmodel/SearchViewModel.kt`](diffhunk://#diff-2fa637d7f4e20ddf9b74df5359584779f389425164b85aa7894d322c6648938dL20-R20): Updated `SearchViewModel` to use `SearchEffect` instead of `SearchUiEvent` and replaced calls to `sendEvent` with `sendEffect`. [[1]](diffhunk://#diff-2fa637d7f4e20ddf9b74df5359584779f389425164b85aa7894d322c6648938dL20-R20) [[2]](diffhunk://#diff-2fa637d7f4e20ddf9b74df5359584779f389425164b85aa7894d322c6648938dL53-R53) [[3]](diffhunk://#diff-2fa637d7f4e20ddf9b74df5359584779f389425164b85aa7894d322c6648938dL138-R138) [[4]](diffhunk://#diff-2fa637d7f4e20ddf9b74df5359584779f389425164b85aa7894d322c6648938dL159-R159) [[5]](diffhunk://#diff-2fa637d7f4e20ddf9b74df5359584779f389425164b85aa7894d322c6648938dL177-R177)

### Mapper Updates:
* [`viewmodel/src/main/java/com/cairosquad/viewmodel/searchviewmodel/mapper.kt`](diffhunk://#diff-cba3b978d6b3a0440ddfc2edba7265c0369b3ef445e0d25c3bdb881fc1530a39L7-R20): Updated mappers to align with the new `SearchScreenState` naming conventions (`MovieScreenState` → `MovieUiState`, etc.).

### Test Updates:
* [`viewmodel/src/test/java/com/cairosquad/viewmodel/base/BaseViewModelTest.kt`](diffhunk://#diff-44dffaacd5788d541d0a75ae5e8e33bad93c6b64ebaf3f40eb1cf482e349d355L43-R43): Updated tests to reflect the refactored `BaseViewModel` changes, including renaming test methods and variables to use "effects" instead of "events." [[1]](diffhunk://#diff-44dffaacd5788d541d0a75ae5e8e33bad93c6b64ebaf3f40eb1cf482e349d355L43-R43) [[2]](diffhunk://#diff-44dffaacd5788d541d0a75ae5e8e33bad93c6b64ebaf3f40eb1cf482e349d355L95-R98) [[3]](diffhunk://#diff-44dffaacd5788d541d0a75ae5e8e33bad93c6b64ebaf3f40eb1cf482e349d355L139-R139)

### UI Component Updates:
* [`ui/src/main/java/com/cairosquad/ui/search/content/SearchResultContent.kt`](diffhunk://#diff-cbeebff283c1c13aedfd35a07bb0a8e64b2001fd2102aaebc631e1e4f3c4683bL131-R131): Updated composable functions to use the renamed `MovieUiState`, `SeriesUiState`, and `ArtistUiState` types instead of their previous counterparts. [[1]](diffhunk://#diff-cbeebff283c1c13aedfd35a07bb0a8e64b2001fd2102aaebc631e1e4f3c4683bL131-R131) [[2]](diffhunk://#diff-cbeebff283c1c13aedfd35a07bb0a8e64b2001fd2102aaebc631e1e4f3c4683bL178-R178) [[3]](diffhunk://#diff-cbeebff283c1c13aedfd35a07bb0a8e64b2001fd2102aaebc631e1e4f3c4683bL224-R224) [[4]](diffhunk://#diff-cbeebff283c1c13aedfd35a07bb0a8e64b2001fd2102aaebc631e1e4f3c4683bL270-R270)…erences