### PR TITLE
Allow 'ci' as valid branch prefix in CI workflow

### DIFF
--- a/.github/workflows/branch-name-checking-ci.yml
+++ b/.github/workflows/branch-name-checking-ci.yml
@@ -14,7 +14,7 @@ jobs:
           github-token: ${{ secrets.GITHUB_TOKEN }}
           script: |
             const branchName = context.payload.pull_request.head.ref;
-            const regex = /^(feature|feat|fix|test|refactor|chore|style|docs|component)\/[\w-]+$/;
+            const regex = /^(feature|feat|fix|test|refactor|chore|style|docs|component|ci)\/[\w-]+$/;
 
             if (!regex.test(branchName)) {
               core.setFailed('Branch name does not match the required format: <type>/<branch-name>. Allowed types: feature,feat,fix,test,refactor,chore,style,docs');


### PR DESCRIPTION
Updated the branch name validation regex in the branch-name-checking CI workflow to include 'ci' as an allowed branch type.