### PR TITLE
refactor: fix the cut in the grid items at the end of the screen.

### DIFF
--- a/.github/workflows/cd-firebase.yml
+++ b/.github/workflows/cd-firebase.yml
@@ -5,7 +5,6 @@ on:
     branches:
       - develop
       - master
-      - refactor/app-not-distributed-to-firebase
 
 jobs:
   deploy:

--- a/design_system/src/main/java/com/cairosquad/design_system/component/SectionHeader.kt
+++ b/design_system/src/main/java/com/cairosquad/design_system/component/SectionHeader.kt
@@ -35,7 +35,7 @@ fun SectionHeader(
     modifier: Modifier = Modifier,
     actionText: String? = null,
     actionIcon: ImageVector? = null,
-    onActionClick: () -> Unit
+    onActionClick: () -> Unit = {}
 ) {
     Row(
         verticalAlignment = Alignment.CenterVertically,

--- a/ui/src/main/java/com/cairosquad/ui/search/content/ExploreScreenContent.kt
+++ b/ui/src/main/java/com/cairosquad/ui/search/content/ExploreScreenContent.kt
@@ -79,7 +79,11 @@ fun ExploreScreenContent(
                 onValueChange = listener::onQueryTextChanged,
                 placeholder = stringResource(R.string.search),
                 leadingIcon = R.drawable.search_bottom_nav,
-                onFocusChanged = { if (it) { listener.onClickSearchTextField() } },
+                onFocusChanged = {
+                    if (it) {
+                        listener.onClickSearchTextField()
+                    }
+                },
                 readOnly = true
             )
         }
@@ -112,9 +116,6 @@ fun ExploreScreenContent(
         item {
             SectionHeader(
                 title = stringResource(R.string.explore_more),
-                actionText = stringResource(R.string.see_all),
-                actionIcon = ImageVector.vectorResource(R.drawable.arrow),
-                onActionClick = {}
             )
 
         }
@@ -123,7 +124,7 @@ fun ExploreScreenContent(
                 modifier = Modifier
                     .fillMaxWidth()
                     .padding(horizontal = 16.dp)
-                    .heightIn(max = ((state.exploreMore.size / 2 + 1) * 240).dp),
+                    .heightIn(max = (state.exploreMore.size * 2 * 240).dp),
                 columns = GridCells.Adaptive(minSize = 158.dp),
                 verticalArrangement = Arrangement.spacedBy(16.dp),
                 horizontalArrangement = Arrangement.spacedBy(12.dp),

--- a/ui/src/main/java/com/cairosquad/ui/search/content/SearchResultContent.kt
+++ b/ui/src/main/java/com/cairosquad/ui/search/content/SearchResultContent.kt
@@ -9,10 +9,10 @@ import androidx.compose.foundation.background
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.PaddingValues
 import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.fillMaxSize
-import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.lazy.grid.GridCells
@@ -65,7 +65,7 @@ fun SearchResultContent(
     Column(
         modifier = modifier
             .fillMaxSize()
-            .padding(16.dp)
+            .padding(horizontal = 16.dp)
     ) {
 
         InputField(
@@ -101,25 +101,21 @@ fun SearchResultContent(
                 SearchResultText(
                     noOfResults = state.movies.size
                 )
-                Spacer(modifier = Modifier.height(16.dp))
                 AllResultsTabContent(topResults = state.movies)
             }
 
             1 -> {
                 SearchResultText(noOfResults = state.movies.size)
-                Spacer(modifier = Modifier.height(16.dp))
                 MoviesTabContent(movies = state.movies)
             }
 
             2 -> {
                 SearchResultText(noOfResults = state.series.size)
-                Spacer(modifier = Modifier.height(16.dp))
                 SeriesTabContent(series = state.series)
             }
 
             3 -> {
                 SearchResultText(noOfResults = state.artists.size)
-                Spacer(modifier = Modifier.height(16.dp))
                 ArtistsTabContent(artists = state.artists)
             }
         }
@@ -140,7 +136,7 @@ private fun AllResultsTabContent(
             modifier = modifier
                 .fillMaxSize(),
             contentAlignment = Alignment.Center
-        ){
+        ) {
             StateMessage(
                 imageDrawable = R.drawable.no_result,
                 titleId = R.string.no_results_found,
@@ -156,9 +152,10 @@ private fun AllResultsTabContent(
     ) {
         LazyVerticalGrid(
             modifier = modifier,
-            columns = GridCells.Adaptive(minSize = 100.dp),
+            columns = GridCells.Adaptive(minSize = 101.33.dp),
             horizontalArrangement = Arrangement.spacedBy(12.dp),
-            verticalArrangement = Arrangement.spacedBy(12.dp)
+            verticalArrangement = Arrangement.spacedBy(12.dp),
+            contentPadding = PaddingValues(bottom = 16.dp)
         ) {
             items(topResults) { result ->
                 MovieCard(
@@ -202,9 +199,10 @@ private fun MoviesTabContent(
     ) {
         LazyVerticalGrid(
             modifier = modifier,
-            columns = GridCells.Adaptive(minSize = 100.dp),
+            columns = GridCells.Adaptive(minSize = 101.33.dp),
             horizontalArrangement = Arrangement.spacedBy(12.dp),
-            verticalArrangement = Arrangement.spacedBy(12.dp)
+            verticalArrangement = Arrangement.spacedBy(12.dp),
+            contentPadding = PaddingValues(bottom = 16.dp)
         ) {
             items(movies) { movie ->
                 MovieCard(
@@ -248,9 +246,10 @@ private fun SeriesTabContent(
     ) {
         LazyVerticalGrid(
             modifier = modifier,
-            columns = GridCells.Adaptive(minSize = 100.dp),
+            columns = GridCells.Adaptive(minSize = 101.33.dp),
             horizontalArrangement = Arrangement.spacedBy(12.dp),
-            verticalArrangement = Arrangement.spacedBy(12.dp)
+            verticalArrangement = Arrangement.spacedBy(12.dp),
+            contentPadding = PaddingValues(bottom = 16.dp)
         ) {
             items(series) { series ->
                 MovieCard(
@@ -294,9 +293,10 @@ private fun ArtistsTabContent(
     ) {
         LazyVerticalGrid(
             modifier = modifier,
-            columns = GridCells.Adaptive(minSize = 100.dp),
+            columns = GridCells.Adaptive(minSize = 101.33.dp),
             horizontalArrangement = Arrangement.spacedBy(12.dp),
-            verticalArrangement = Arrangement.spacedBy(12.dp)
+            verticalArrangement = Arrangement.spacedBy(12.dp),
+            contentPadding = PaddingValues(bottom = 16.dp)
         ) {
             items(artists) { artist ->
                 ArtistCard(
@@ -308,14 +308,13 @@ private fun ArtistsTabContent(
     }
 }
 
-
 @Composable
 fun SearchResultText(
     noOfResults: Int,
     modifier: Modifier = Modifier
 ) {
     Row(
-        modifier = modifier,
+        modifier = modifier.padding(bottom = 16.dp),
         verticalAlignment = Alignment.CenterVertically
     ) {
         BasicText(


### PR DESCRIPTION
### Changes in this PR:
- Fixed an issue with items being cut at the end of the grid in the Explore screen.
- Fixed an issue with padding in the Results screen.

<table>
  <thead>
    <tr>
      <th>Before</th>
      <th>After</th>
    </tr>
  </thead>
  <tbody>
    <tr>
      <td>
        <video src="https://github.com/user-attachments/assets/092f3746-b613-475f-8720-2722bcdd7424" controls width="300"></video>
      </td>
      <td>
        <video src="https://github.com/user-attachments/assets/4c6544fc-6d59-40a4-be8e-17fc243be38b" controls width="300"></video>
      </td>
    </tr>
    <tr>
      <td>
        <video src="https://github.com/user-attachments/assets/ff3bacbe-b392-421f-84c7-d53bc4b85f98" controls width="300"></video>
      </td>
      <td>
        <video src="https://github.com/user-attachments/assets/788e0249-ea20-4abc-9472-7880748e4d6c" controls width="300"></video>
      </td>
    </tr>
  </tbody>
</table>