### PR TITLE
fix: top padding in the results screen, and make system nav bar trans…

### DIFF
--- a/design_system/src/main/java/com/cairosquad/design_system/basic_component/NavigationBar.kt
+++ b/design_system/src/main/java/com/cairosquad/design_system/basic_component/NavigationBar.kt
@@ -66,8 +66,8 @@ fun NavigationBar(
                 alpha = 0.06f
             )
             .background(color = Theme.color.surfaces.surface)
-            .height(74.dp)
             .windowInsetsPadding(WindowInsets.navigationBars)
+            .height(74.dp)
             .padding(horizontal = 20.dp)
             .fillMaxWidth(),
         verticalAlignment = Alignment.CenterVertically,

--- a/design_system/src/main/java/com/cairosquad/design_system/basic_component/NavigationBar.kt
+++ b/design_system/src/main/java/com/cairosquad/design_system/basic_component/NavigationBar.kt
@@ -67,11 +67,10 @@ fun NavigationBar(
             )
             .background(color = Theme.color.surfaces.surface)
             .windowInsetsPadding(WindowInsets.navigationBars)
-            .height(74.dp)
-            .padding(horizontal = 20.dp)
+            .padding(horizontal = 20.dp, vertical = 15.5.dp)
             .fillMaxWidth(),
         verticalAlignment = Alignment.CenterVertically,
-        horizontalArrangement = Arrangement.SpaceBetween,
+        horizontalArrangement = Arrangement.spacedBy(8.dp),
     ) {
         navigationItems.forEachIndexed { index, item ->
             val iconResId = if (selectedMenu == index) item.coloredIcon else item.unColoredIcon
@@ -86,10 +85,11 @@ fun NavigationBar(
             )
             Column(
                 modifier = Modifier
-                    .size(height = 43.dp, width = 74.dp)
+                    .weight(1f)
                     .clip(RoundedCornerShape(8.dp))
                     .clickable { onMenuClick(index) },
-                horizontalAlignment = Alignment.CenterHorizontally
+                horizontalAlignment = Alignment.CenterHorizontally,
+                verticalArrangement = Arrangement.spacedBy(4.dp)
             ) {
                 AnimatedContent(
                     targetState = iconResId,

--- a/design_system/src/main/java/com/cairosquad/design_system/basic_component/Scaffold.kt
+++ b/design_system/src/main/java/com/cairosquad/design_system/basic_component/Scaffold.kt
@@ -1,17 +1,11 @@
 package com.cairosquad.design_system.basic_component
 
-import androidx.compose.foundation.background
 import androidx.compose.foundation.layout.Box
-import androidx.compose.foundation.layout.WindowInsets
+import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
-import androidx.compose.foundation.layout.systemBars
-import androidx.compose.foundation.layout.windowInsetsPadding
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Modifier
-import androidx.constraintlayout.compose.ConstraintLayout
-import androidx.constraintlayout.compose.Dimension
-import com.cairosquad.design_system.theme.Theme
 
 @Composable
 fun Scaffold(
@@ -20,45 +14,18 @@ fun Scaffold(
     content: @Composable () -> Unit,
     modifier: Modifier = Modifier
 ) {
-    ConstraintLayout(
+    Column (
         modifier = modifier
             .fillMaxSize()
-            .background(Theme.color.surfaces.surface)
-            .windowInsetsPadding(WindowInsets.systemBars)
     ) {
-        val (topBar, content, navBar) = createRefs()
-        Box(
-            modifier = Modifier
-                .constrainAs(content) {
-                    top.linkTo(topBar.bottom)
-                    bottom.linkTo(navBar.top)
-                    start.linkTo(parent.start)
-                    end.linkTo(parent.end)
-                    height = Dimension.fillToConstraints
-                }) {
-            content()
-        }
-        Box(
-            modifier = Modifier
-                .fillMaxWidth()
-                .constrainAs(topBar) {
-                    top.linkTo(parent.top)
-                    start.linkTo(parent.start)
-                    end.linkTo(parent.end)
-                }
-        ) {
             topBar()
-        }
-        Box(
-            modifier = Modifier
-                .fillMaxWidth()
-                .constrainAs(navBar) {
-                    bottom.linkTo(parent.bottom)
-                    start.linkTo(parent.start)
-                    end.linkTo(parent.end)
-                }
-        ) {
+            Box(
+                modifier = Modifier
+                    .fillMaxWidth()
+                    .weight(1f)
+            ) {
+                content()
+            }
             navBar()
-        }
     }
 }

--- a/ui/src/main/java/com/cairosquad/ui/AppScreen.kt
+++ b/ui/src/main/java/com/cairosquad/ui/AppScreen.kt
@@ -10,7 +10,6 @@ import androidx.compose.runtime.remember
 import androidx.compose.runtime.saveable.rememberSaveable
 import androidx.compose.runtime.setValue
 import androidx.compose.ui.tooling.preview.Preview
-import androidx.navigation.NavHostController
 import com.cairosquad.design_system.R
 import com.cairosquad.design_system.basic_component.BottomNavItem
 import com.cairosquad.design_system.basic_component.NavigationBar

--- a/ui/src/main/java/com/cairosquad/ui/MainActivity.kt
+++ b/ui/src/main/java/com/cairosquad/ui/MainActivity.kt
@@ -1,5 +1,6 @@
 package com.cairosquad.ui
 
+import android.os.Build
 import android.os.Bundle
 import androidx.activity.ComponentActivity
 import androidx.activity.compose.setContent
@@ -11,6 +12,11 @@ class MainActivity : ComponentActivity() {
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
         enableEdgeToEdge()
+
+        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.Q) {
+            window.setNavigationBarContrastEnforced(false)
+        }
+
         setContent {
             MovioTheme {
                 AppNavigation()

--- a/ui/src/main/java/com/cairosquad/ui/search/SearchScreen.kt
+++ b/ui/src/main/java/com/cairosquad/ui/search/SearchScreen.kt
@@ -56,4 +56,3 @@ fun SearchScreen(
         modifier = modifier.windowInsetsPadding(WindowInsets.statusBars)
     )
 }
-

--- a/ui/src/main/java/com/cairosquad/ui/search/SearchScreen.kt
+++ b/ui/src/main/java/com/cairosquad/ui/search/SearchScreen.kt
@@ -1,6 +1,9 @@
 package com.cairosquad.ui.search
 
 import android.widget.Toast
+import androidx.compose.foundation.layout.WindowInsets
+import androidx.compose.foundation.layout.statusBars
+import androidx.compose.foundation.layout.windowInsetsPadding
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.collectAsState
 import androidx.compose.runtime.getValue
@@ -50,7 +53,7 @@ fun SearchScreen(
     SearchScreenContent(
         state = state,
         listener = viewModel,
-        modifier = modifier
+        modifier = modifier.windowInsetsPadding(WindowInsets.statusBars)
     )
 }
 

--- a/ui/src/main/java/com/cairosquad/ui/search/content/ExploreScreenContent.kt
+++ b/ui/src/main/java/com/cairosquad/ui/search/content/ExploreScreenContent.kt
@@ -8,7 +8,6 @@ import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.PaddingValues
 import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.fillMaxSize
-import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.heightIn
 import androidx.compose.foundation.layout.padding
@@ -125,7 +124,7 @@ fun ExploreScreenContent(
         item {
             LazyVerticalGrid(
                 modifier = Modifier
-                    .fillMaxWidth()
+                    .fillMaxSize()
                     .padding(horizontal = 16.dp)
                     .heightIn(max = (state.exploreMore.size * 2 * 240).dp),
                 columns = GridCells.Adaptive(minSize = 158.dp),

--- a/ui/src/main/java/com/cairosquad/ui/search/content/SearchResultContent.kt
+++ b/ui/src/main/java/com/cairosquad/ui/search/content/SearchResultContent.kt
@@ -66,7 +66,7 @@ fun SearchResultContent(
     Column(
         modifier = modifier
             .fillMaxSize()
-            .padding(horizontal = 16.dp)
+            .padding(start = 16.dp, top = 16.dp,  end = 16.dp)
     ) {
 
         InputField(


### PR DESCRIPTION
fix top padding in the results screen, and make system nav bar transparent

before | after
--- | ---
<img width="399" height="888" alt="image" src="https://github.com/user-attachments/assets/ac6ea281-55db-4d8b-beaa-408eace84613" /> | <img width="406" height="889" alt="image" src="https://github.com/user-attachments/assets/b87d81a5-b359-4a31-9380-44cd67340dd2" />

