### PR TITLE
Fix/make selected tab saved

### DIFF
--- a/ui/src/main/java/com/cairosquad/ui/search/content/SearchResultContent.kt
+++ b/ui/src/main/java/com/cairosquad/ui/search/content/SearchResultContent.kt
@@ -61,7 +61,7 @@ fun SearchResultContent(
         }
     }
 
-    var selectedTabIndex by remember { mutableIntStateOf(0) }
+    val selectedTabIndex = state.selectedTabIndex
 
     Column(
         modifier = modifier
@@ -94,7 +94,7 @@ fun SearchResultContent(
                 stringResource(R.string.artists),
             ),
             selectedTabIndex = selectedTabIndex,
-            onTabSelected = { selectedTabIndex = it }
+            onTabSelected = { listener.onTabSelected(it) }
         )
 
         when (selectedTabIndex) {

--- a/ui/src/main/java/com/cairosquad/ui/search/content/SearchResultContent.kt
+++ b/ui/src/main/java/com/cairosquad/ui/search/content/SearchResultContent.kt
@@ -22,10 +22,6 @@ import androidx.compose.foundation.lazy.grid.items
 import androidx.compose.foundation.text.BasicText
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.DisposableEffect
-import androidx.compose.runtime.getValue
-import androidx.compose.runtime.mutableIntStateOf
-import androidx.compose.runtime.remember
-import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.res.stringResource

--- a/viewmodel/src/main/java/com/cairosquad/viewmodel/search/SearchInteractionListener.kt
+++ b/viewmodel/src/main/java/com/cairosquad/viewmodel/search/SearchInteractionListener.kt
@@ -14,4 +14,5 @@ interface SearchInteractionListener {
     fun onSeriesClicked(seriesId: Long)
     fun onArtistClicked(artistId: Long)
     fun onSeeAllForYouClicked()
+    fun onTabSelected(index: Int)
 }

--- a/viewmodel/src/main/java/com/cairosquad/viewmodel/search/SearchScreenState.kt
+++ b/viewmodel/src/main/java/com/cairosquad/viewmodel/search/SearchScreenState.kt
@@ -4,6 +4,7 @@ import com.cairosquad.viewmodel.exception.ErrorStatus
 
 data class SearchScreenState(
     val query: String = "",
+    val selectedTabIndex: Int = 0,
     val screenStatus: ScreenStatus = ScreenStatus.LOADING,
     val errorStatus: ErrorStatus? = null,
     val recentSearch: List<String> = emptyList(),

--- a/viewmodel/src/main/java/com/cairosquad/viewmodel/search/SearchViewModel.kt
+++ b/viewmodel/src/main/java/com/cairosquad/viewmodel/search/SearchViewModel.kt
@@ -266,6 +266,10 @@ class SearchViewModel(
         sendEffect(SearchEffect.NavigateToSeeAllForYouScreen)
     }
 
+    override fun onTabSelected(index: Int) {
+        updateState { it.copy(selectedTabIndex = index) }
+    }
+
     private fun handleSearchException(e: Throwable): ErrorStatus {
         return when (e) {
             is MovioException -> {


### PR DESCRIPTION
Move the selected tab index to SearchScreenState to preserve the user's selected tab when navigating back to the screen.
Previously, it always reset to the first tab.

