### PR TITLE
fix: bug 104 - tabs bar indicator issue

### DIFF
--- a/design_system/src/main/java/com/cairosquad/design_system/basic_component/TabRow.kt
+++ b/design_system/src/main/java/com/cairosquad/design_system/basic_component/TabRow.kt
@@ -52,6 +52,9 @@ fun TabRow(
     val layoutDirection = LocalLayoutDirection.current
     val density = LocalDensity.current
 
+    val horizontalScrollingState = rememberScrollState()
+    val horizontalScrollingValueDp = with(density) { horizontalScrollingState.value.toDp() }
+
     val indicatorOffsetX by animateDpAsState(
         targetValue = with(density) {
             tabPositions[selectedTabIndex]?.let { (xPx, widthPx) ->
@@ -78,7 +81,7 @@ fun TabRow(
             modifier = Modifier
                 .fillMaxWidth()
                 .height(36.dp)
-                .horizontalScroll(rememberScrollState())
+                .horizontalScroll(horizontalScrollingState)
                 .onGloballyPositioned { rowWidthPx = it.size.width },
             horizontalArrangement = Arrangement.SpaceAround,
             verticalAlignment = Alignment.CenterVertically
@@ -124,7 +127,7 @@ fun TabRow(
         if (tabPositions.containsKey(selectedTabIndex)) {
             Box(
                 modifier = Modifier
-                    .offset(x = indicatorOffsetX)
+                    .offset(x = indicatorOffsetX - horizontalScrollingValueDp)
                     .height(1.dp)
                     .width(indicatorWidth)
                     .align(Alignment.BottomStart)


### PR DESCRIPTION
fix: tabs bar indicator issue

<table>
  <thead>
    <tr>
      <th>before</th>
      <th>after</th>
    </tr>
  </thead>
  <tbody>
    <tr>
      <td><video src="https://github.com/user-attachments/assets/d62470f4-5c97-4e37-9f2a-42e513a2663c" alt="Before" /></td>
      <td><video src="https://github.com/user-attachments/assets/10818f24-e9e3-4643-ab0a-616579c94a93" alt="After" /></td>
    </tr>
  </tbody>
</table>


