### PR TITLE
fix: background color for the season card.

### DIFF
--- a/ui/src/main/java/com/cairosquad/ui/movio_component/SeasonCard.kt
+++ b/ui/src/main/java/com/cairosquad/ui/movio_component/SeasonCard.kt
@@ -48,8 +48,7 @@ fun SeasonCard(
         modifier = modifier
             .fillMaxWidth()
             .clip(RoundedCornerShape(8.dp))
-            .clickable { onClick() }
-            .background(color = Theme.color.surfaces.surface),
+            .clickable { onClick() },
         verticalAlignment = Alignment.Top
     ) {
         if (movieImage?.isNotEmpty() == true) {


### PR DESCRIPTION
Changes in this PR:
- Removed the background color for the season card to match the design.
<table>
  <thead>
    <tr>
      <th>before</th>
      <th>after</th>
    </tr>
  </thead>
  <tbody>
    <tr>
      <td><img width="324" height="719" alt="image" src="https://github.com/user-attachments/assets/f54d086d-f4fd-4c86-a03d-587dfaa0507b" /></td>
      <td><img width="324" height="719" alt="image" src="https://github.com/user-attachments/assets/3bc758d6-7d52-4383-84bb-b3aac30a7ef2" /></td>
    </tr>
  </tbody>
</table>


