### PR TITLE
Restrict WebView navigation to themoviedb.org

### DIFF
--- a/design_system/src/main/java/com/cairosquad/design_system/basic_component/WebView.kt
+++ b/design_system/src/main/java/com/cairosquad/design_system/basic_component/WebView.kt
@@ -42,13 +42,13 @@ fun WebView(
                         val uri = Uri.parse(url)
                         val isTmdbDomain = uri.host == "www.themoviedb.org"
                         val allowedPaths = listOf(
-                            "signup", "reset-password", "reset-password/confirm", "/login"
+                            "signup", "reset-password"
                         )
-                        val isAuthPath = uri.path?.startsWith("/authenticate") == true
 
-                        val isAllowed = isTmdbDomain && (uri.path in allowedPaths || isAuthPath)
+                        val isAllowed = isTmdbDomain && (uri.path in allowedPaths)
 
                         if (!isAllowed) {
+                            Log.d("WebView","Navigation blocked: $url")
                             Toast.makeText(context, "Navigation blocked", Toast.LENGTH_SHORT).show()
                         }
 

--- a/design_system/src/main/java/com/cairosquad/design_system/basic_component/WebView.kt
+++ b/design_system/src/main/java/com/cairosquad/design_system/basic_component/WebView.kt
@@ -4,6 +4,7 @@ package com.cairosquad.design_system.basic_component
 
 import android.annotation.SuppressLint
 import android.net.Uri
+import android.util.Log
 import android.webkit.WebView
 import android.webkit.WebViewClient
 import android.widget.Toast
@@ -19,9 +20,7 @@ import androidx.compose.ui.viewinterop.AndroidView
 @SuppressLint("SetJavaScriptEnabled")
 @Composable
 fun WebView(
-    webPageUrl: String,
-    modifier: Modifier = Modifier,
-    onBackPressed: (() -> Unit)? = null
+    webPageUrl: String, modifier: Modifier = Modifier, onBackPressed: (() -> Unit)? = null
 ) {
     var webView by remember { mutableStateOf<WebView?>(null) }
 
@@ -41,18 +40,25 @@ fun WebView(
                 webViewClient = object : WebViewClient() {
                     override fun shouldOverrideUrlLoading(view: WebView, url: String): Boolean {
                         val uri = Uri.parse(url)
-                        return if (uri.host == "www.themoviedb.org") {
-                            false // allow internal navigation
-                        } else {
+                        val isTmdbDomain = uri.host == "www.themoviedb.org"
+                        val allowedPaths = listOf(
+                            "signup", "reset-password", "reset-password/confirm", "/login"
+                        )
+                        val isAuthPath = uri.path?.startsWith("/authenticate") == true
+
+                        val isAllowed = isTmdbDomain && (uri.path in allowedPaths || isAuthPath)
+
+                        if (!isAllowed) {
                             Toast.makeText(context, "Navigation blocked", Toast.LENGTH_SHORT).show()
-                            return true
                         }
+
+                        return !isAllowed // true = block, false = allow
                     }
                 }
+
                 loadUrl(webPageUrl)
                 webView = this
             }
-        },
-        modifier = modifier
+        }, modifier = modifier
     )
 }

--- a/design_system/src/main/java/com/cairosquad/design_system/basic_component/WebView.kt
+++ b/design_system/src/main/java/com/cairosquad/design_system/basic_component/WebView.kt
@@ -3,8 +3,10 @@
 package com.cairosquad.design_system.basic_component
 
 import android.annotation.SuppressLint
+import android.net.Uri
 import android.webkit.WebView
 import android.webkit.WebViewClient
+import android.widget.Toast
 import androidx.activity.compose.BackHandler
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.getValue
@@ -36,7 +38,17 @@ fun WebView(
             WebView(context).apply {
                 settings.javaScriptEnabled = true
                 settings.domStorageEnabled = true
-                webViewClient = WebViewClient()
+                webViewClient = object : WebViewClient() {
+                    override fun shouldOverrideUrlLoading(view: WebView, url: String): Boolean {
+                        val uri = Uri.parse(url)
+                        return if (uri.host == "www.themoviedb.org") {
+                            false // allow internal navigation
+                        } else {
+                            Toast.makeText(context, "Navigation blocked", Toast.LENGTH_SHORT).show()
+                            return true
+                        }
+                    }
+                }
                 loadUrl(webPageUrl)
                 webView = this
             }


### PR DESCRIPTION
Updated the WebView component to block navigation to external domains, allowing only internal navigation within www.themoviedb.org. Displays a toast message when navigation is blocked.<br>

https://github.com/user-attachments/assets/c01ff116-6267-4242-acbb-014621524318

