### PR TITLE
Lower password minimum length to 4 characters

### DIFF
--- a/ui/src/main/java/com/cairosquad/ui/utils/validationErrorToStringResource.kt
+++ b/ui/src/main/java/com/cairosquad/ui/utils/validationErrorToStringResource.kt
@@ -14,7 +14,7 @@ fun validationErrorToStringResource(
         LoginScreenState.ValidationError.TOO_SHORT_FIELD -> {
             when (field) {
                 LoginScreenState.FormField.USERNAME -> R.string.username_must_be_at_least_2_characters_long
-                LoginScreenState.FormField.PASSWORD -> R.string.password_must_be_at_least_8_characters_long
+                LoginScreenState.FormField.PASSWORD -> R.string.password_must_be_at_least_4_characters_long
             }
         }
     }

--- a/ui/src/main/res/values-ar/strings.xml
+++ b/ui/src/main/res/values-ar/strings.xml
@@ -20,7 +20,7 @@
     <string name="password">كلمة السر</string>
     <string name="this_field_cannot_be_empty">هذا الحقل مطلوب</string>
     <string name="username_must_be_at_least_2_characters_long">اسم المستخدم لا بد أن يكون حرفان على الأقل</string>
-    <string name="password_must_be_at_least_8_characters_long">كلمة المرور لا بد أن تكون 8 حروف على الأقل</string>
+    <string name="password_must_be_at_least_4_characters_long">كلمة المرور لا بد أن تكون  4 حروف على الأقل</string>
     <string name="create">إنشاء</string>
     <string name="list_name">إسم القائمة</string>
     <string name="movie">فيلم</string>

--- a/ui/src/main/res/values/strings.xml
+++ b/ui/src/main/res/values/strings.xml
@@ -20,7 +20,7 @@
     <string name="password">Password</string>
     <string name="this_field_cannot_be_empty">This field is required</string>
     <string name="username_must_be_at_least_2_characters_long">Username must be at least 2 characters long</string>
-    <string name="password_must_be_at_least_8_characters_long">Password must be at least 8 characters long</string>
+    <string name="password_must_be_at_least_4_characters_long">Password must be at least 4 characters long</string>
     <string name="create">Create</string>
     <string name="list_name">List name</string>
     <string name="movie">Movie</string>

--- a/viewmodel/src/main/java/com/cairosquad/viewmodel/login/LoginViewModel.kt
+++ b/viewmodel/src/main/java/com/cairosquad/viewmodel/login/LoginViewModel.kt
@@ -154,7 +154,7 @@ class LoginViewModel(
                     }
                 )
             }
-        } else if (password.length < 8) {
+        } else if (password.length < 4) {
             updateState {
                 it.copy(
                     errors = it.errors.toMutableMap().apply {

--- a/viewmodel/src/test/java/com/cairosquad/viewmodel/login/LoginViewModelTest.kt
+++ b/viewmodel/src/test/java/com/cairosquad/viewmodel/login/LoginViewModelTest.kt
@@ -132,7 +132,7 @@ class LoginViewModelTest {
 
     @Test
     fun `WHEN login clicked with short password SHOULD validate password`() = runTest {
-        viewModel.onPasswordChange("1234567")
+        viewModel.onPasswordChange("123")
         viewModel.onLoginClick()
         advanceUntilIdle()
         assertThat(viewModel.screenState.value.errors[LoginScreenState.FormField.PASSWORD]).isEqualTo(


### PR DESCRIPTION
fixed #382 by Reducing the minimum required password length from 8 to 4 characters in validation logic and updated corresponding string resources in both English and Arabic. This change ensures consistency across UI and validation checks.