### PR TITLE
fix : fix season card taking the whole row when the image is null

### DIFF
--- a/ui/src/main/java/com/cairosquad/ui/movio_component/SeasonCard.kt
+++ b/ui/src/main/java/com/cairosquad/ui/movio_component/SeasonCard.kt
@@ -67,7 +67,7 @@ fun SeasonCard(
         } else {
             Box(
                 modifier = Modifier
-                    .fillMaxSize()
+                    .size(width = 76.dp, height = 100.dp)
                     .clip(RoundedCornerShape(8.dp))
                     .background(Theme.color.system.defaultImageBackground),
                 contentAlignment = Alignment.Center


### PR DESCRIPTION
before : 
<img width="491" height="372" alt="image" src="https://github.com/user-attachments/assets/33cc2052-710d-4f3f-8382-7e328c1547c0" />
after : 
<img width="474" height="379" alt="image" src="https://github.com/user-attachments/assets/66d87929-5dfc-4991-81bc-68dda7ba18c2" />
