### PR TITLE
fix : put correct image for favourite list empty

### DIFF
--- a/ui/src/main/java/com/cairosquad/ui/library/view_all/ViewAllFavorite.kt
+++ b/ui/src/main/java/com/cairosquad/ui/library/view_all/ViewAllFavorite.kt
@@ -209,7 +209,7 @@ fun ViewAllFavoriteContent(
             else {
                 Spacer(Modifier.weight(1f))
                 StateMessage(
-                    imageDrawable = com.cairosquad.design_system.R.drawable.watch_later_empty,
+                    imageDrawable = com.cairosquad.design_system.R.drawable.favorite_list_empty,
                     title = stringResource(com.cairosquad.design_system.R.string.favorites_list_empty),
                     description = stringResource(com.cairosquad.design_system.R.string.favorite_list_empty_description)
                 )


### PR DESCRIPTION
fix issue icon not correct in favourite screen 
fix : #555 

BEFORE :
<img width="718" height="701" alt="لقطة الشاشة 2025-08-13 213253" src="https://github.com/user-attachments/assets/9b88e3b6-717a-4c34-b2ca-8c2771cc17e9" />


AFTER :
<img width="720" height="690" alt="image" src="https://github.com/user-attachments/assets/6783ee08-9e6f-44fd-8dec-9134f5b83a92" />

