### PR TITLE
fix:fix padding at finish rating bottom sheet

### DIFF
--- a/ui/src/main/java/com/cairosquad/ui/movio_component/RatingBar.kt
+++ b/ui/src/main/java/com/cairosquad/ui/movio_component/RatingBar.kt
@@ -43,8 +43,7 @@ fun RatingBar(
             )
             Icon(
                 modifier = Modifier
-                    .scale(if (isRateLarge && rate == rating) 2f else 1f)
-                    .size(24.dp)
+                    .size(if (isRateLarge && rate == rating) 48.dp else 28.dp)
                     .clip(RoundedCornerShape(8.dp))
                     .then(
                         if (isClickable) {


### PR DESCRIPTION
before
<img width="705" height="606" alt="image" src="https://github.com/user-attachments/assets/1a7920c3-c569-49d1-afca-259f22070429" />

after
<img width="350" height="323" alt="after" src="https://github.com/user-attachments/assets/8591d7d0-7c11-4463-9024-5d6444406c1e" />
