### PR TITLE
Fix/color of rate numbers at different screens

### DIFF
--- a/design_system/src/main/java/com/cairosquad/design_system/color/MovioColors.kt
+++ b/design_system/src/main/java/com/cairosquad/design_system/color/MovioColors.kt
@@ -9,6 +9,7 @@ data class MovioColors(
     val surfaces: Surfaces,
     val system: System,
     val gradiant: Gradiant,
+    val warning: Warning
 )
 
 data class Surfaces(
@@ -58,6 +59,9 @@ data class Gradiant(
     val primaryGradient: Brush,
     val logo: Brush,
     val fadingGradient: Brush,
+)
+data class Warning(
+    val onWarning: Color
 )
 
 internal val LocalMovioColor = staticCompositionLocalOf { lightThemeColors }

--- a/design_system/src/main/java/com/cairosquad/design_system/color/darkThemeColors.kt
+++ b/design_system/src/main/java/com/cairosquad/design_system/color/darkThemeColors.kt
@@ -77,5 +77,9 @@ val darkThemeColors = MovioColors(
                 Color(0xFF080D24)
             )
         )
+    ),
+    warning = Warning(
+        onWarning = Color(0xFFFFFEF9)
+
     )
 )

--- a/design_system/src/main/java/com/cairosquad/design_system/color/lightThemeColors.kt
+++ b/design_system/src/main/java/com/cairosquad/design_system/color/lightThemeColors.kt
@@ -80,4 +80,8 @@ val lightThemeColors = MovioColors(
             )
         )
     ),
+    warning = Warning(
+        onWarning = Color(0xFFCDBE87)
+
+    )
 )

--- a/ui/src/main/java/com/cairosquad/ui/details/episodes/composable/EpisodeRating.kt
+++ b/ui/src/main/java/com/cairosquad/ui/details/episodes/composable/EpisodeRating.kt
@@ -33,7 +33,7 @@ fun EpisodeRating(episodeName: String, episodeRating: String) {
         )
         BasicText(
             text = episodeRating,
-            style = Theme.textStyle.label.smallRegular12.copy(color = Theme.color.surfaces.onSurface)
+            style = Theme.textStyle.label.smallRegular12.copy(color = Theme.color.warning.onWarning)
         )
     }
 }

--- a/ui/src/main/java/com/cairosquad/ui/movio_component/MovieCard.kt
+++ b/ui/src/main/java/com/cairosquad/ui/movio_component/MovieCard.kt
@@ -121,7 +121,7 @@ fun MovieCard(
 
                 Text(
                     text = String.format(Locale.getDefault(), "%.1f", vote),
-                    color = Theme.color.system.onWarning,
+                    color = Theme.color.warning.onWarning,
                     style = Theme.textStyle.label.smallRegular12
                 )
             }

--- a/ui/src/main/java/com/cairosquad/ui/movio_component/ReviewCard.kt
+++ b/ui/src/main/java/com/cairosquad/ui/movio_component/ReviewCard.kt
@@ -116,7 +116,7 @@ fun ReviewCard(
 				Text(
 					modifier = Modifier.padding(start = 4.dp),
 					text = rating,
-					color = color.system.onWarning,
+					color = color.warning.onWarning,
 					style = textStyle.label.smallRegular12
 				)
 			}

--- a/ui/src/main/java/com/cairosquad/ui/movio_component/SeasonCard.kt
+++ b/ui/src/main/java/com/cairosquad/ui/movio_component/SeasonCard.kt
@@ -143,7 +143,7 @@ fun SeasonCard(
                 BasicText(
                     text = String.format(Locale.getDefault(), "%.1f", seasonRate),
                     style = Theme.textStyle.label.smallRegular12.copy(
-                        color = Theme.color.system.onWarning,
+                        color = Theme.color.warning.onWarning,
                     )
                 )
             }

--- a/ui/src/main/java/com/cairosquad/ui/rated/RatedItemCard.kt
+++ b/ui/src/main/java/com/cairosquad/ui/rated/RatedItemCard.kt
@@ -79,7 +79,6 @@ fun RatedItemCard(
                     overflow = TextOverflow.Ellipsis,
                     modifier = Modifier.padding(bottom = 16.dp)
                 )
-                //create a row with stars representing the rating
                 Row(
                     verticalAlignment = Alignment.CenterVertically,
                     modifier = Modifier
@@ -96,7 +95,7 @@ fun RatedItemCard(
                     Text(
                         text = formattedRating,
                         style = Theme.textStyle.label.smallRegular12,
-                        color = Theme.color.surfaces.onSurface,
+                        color = Theme.color.warning.onWarning,
                         modifier = Modifier.padding(start = 8.dp)
                     )
                 }


### PR DESCRIPTION
before 
<img width="667" height="819" alt="image" src="https://github.com/user-attachments/assets/d4a38120-01a7-4059-ab94-5f058846527b" />
 
after
<img width="311" height="697" alt="image" src="https://github.com/user-attachments/assets/8e95b156-a03b-4762-ab36-bdabc9d6e9d2" />
